### PR TITLE
Make project-path optional by defaulting to current working directory

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -40,7 +40,7 @@ Cliguard is a contract-based validation tool for Cobra CLIs. It ensures that com
 ## Data Flow
 
 1. **User Input**: User runs `cliguard validate` with flags:
-   - `--project-path`: Target project location
+   - `--project-path`: Target project location (defaults to current directory)
    - `--contract`: Contract file path (defaults to `cliguard.yaml`)
    - `--entrypoint`: Function that returns root command
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Cliguard validates Go CLIs built with [Cobra](https://github.com/spf13/cobra) ag
 - **Comprehensive checking**: Validates commands, subcommands, flags, types, and descriptions
 - **CI/CD friendly**: Exit codes and clear output make it perfect for automated pipelines
 - **Dogfooding**: Cliguard validates its own CLI structure
+- **Convenient defaults**: No need to specify `--project-path` when running from your project directory
 
 ## Installation
 
@@ -59,7 +60,7 @@ commands:
     short: Validate a Cobra CLI against a contract file
     flags:
       - name: project-path
-        usage: Path to the root of the target Go project (required)
+        usage: Path to the root of the target Go project (defaults to current directory)
         type: string
       - name: contract
         usage: Path to the contract file (defaults to cliguard.yaml in project path)
@@ -72,7 +73,8 @@ commands:
 3. Run Cliguard on itself:
 
 ```bash
-./cliguard validate --project-path . --entrypoint "github.com/hiAndrewQuinn/cliguard/cmd.NewRootCmd"
+# From the cliguard directory, project-path defaults to current directory
+./cliguard validate --entrypoint "github.com/hiAndrewQuinn/cliguard/cmd.NewRootCmd"
 ```
 
 Output:
@@ -88,7 +90,8 @@ Validating CLI structure against contract...
 1. Generate a contract file from your existing CLI:
 
 ```bash
-cliguard generate --project-path . --entrypoint "github.com/myorg/myapp/cmd.NewRootCmd"
+# From your project directory
+cliguard generate --entrypoint "github.com/myorg/myapp/cmd.NewRootCmd"
 ```
 
 This creates a `cliguard.yaml` file like:
@@ -119,7 +122,8 @@ commands:
 2. Run validation to ensure your CLI structure remains consistent:
 
 ```bash
-cliguard validate --project-path . --entrypoint "github.com/myorg/myapp/cmd.NewRootCmd"
+# From your project directory
+cliguard validate --entrypoint "github.com/myorg/myapp/cmd.NewRootCmd"
 ```
 
 ## Contract Schema
@@ -174,24 +178,37 @@ Supported flag types:
 Generate a contract file from an existing Cobra CLI:
 
 ```bash
+# From your project directory (no --project-path needed)
+cliguard generate
+
+# Or specify a different project
 cliguard generate --project-path /path/to/project
 ```
 
-With a custom output location:
+The generated contract is printed to stdout, so pipe it to a file:
 
 ```bash
-cliguard generate --project-path /path/to/project --output my-contract.yaml
+# From your project directory
+cliguard generate > cliguard.yaml
+
+# Or with a specific project path
+cliguard generate --project-path /path/to/project > my-contract.yaml
 ```
 
 For projects where the root command is returned by a function:
 
 ```bash
-cliguard generate --project-path . --entrypoint "github.com/org/project/cmd.NewRootCmd"
+# From your project directory
+cliguard generate --entrypoint "github.com/org/project/cmd.NewRootCmd" > cliguard.yaml
 ```
 
 ### Basic Validation
 
 ```bash
+# From your project directory (no --project-path needed)
+cliguard validate
+
+# Or validate a different project
 cliguard validate --project-path /path/to/project
 ```
 
@@ -206,7 +223,8 @@ cliguard validate --project-path /path/to/project --contract /path/to/contract.y
 For projects where the root command is returned by a function:
 
 ```bash
-cliguard validate --project-path . --entrypoint "github.com/org/project/cmd.NewRootCmd"
+# From your project directory
+cliguard validate --entrypoint "github.com/org/project/cmd.NewRootCmd"
 ```
 
 ## How It Works
@@ -226,7 +244,7 @@ Add Cliguard to your CI pipeline to catch breaking changes:
 - name: Validate CLI Contract
   run: |
     go install github.com/hiAndrewQuinn/cliguard@latest
-    cliguard validate --project-path . --entrypoint "github.com/org/repo/cmd.NewRootCmd"
+    cliguard validate --entrypoint "github.com/org/repo/cmd.NewRootCmd"
 ```
 
 ## Example Output

--- a/cliguard.yaml
+++ b/cliguard.yaml
@@ -7,7 +7,7 @@ commands:
     short: Generate a contract file from a Cobra CLI
     flags:
       - name: project-path
-        usage: Path to the root of the target Go project (required)
+        usage: Path to the root of the target Go project (defaults to current directory)
         type: string
       - name: entrypoint
         usage: The function that returns the root command (e.g., github.com/user/repo/cmd.NewRootCmd)
@@ -16,7 +16,7 @@ commands:
     short: Validate a Cobra CLI against a contract file
     flags:
       - name: project-path
-        usage: Path to the root of the target Go project (required)
+        usage: Path to the root of the target Go project (defaults to current directory)
         type: string
       - name: contract
         usage: Path to the contract file (defaults to cliguard.yaml in project path)

--- a/cmd/root_extended_test.go
+++ b/cmd/root_extended_test.go
@@ -482,19 +482,23 @@ func TestGenerateCommand(t *testing.T) {
 			},
 		},
 		{
-			name: "missing required project-path",
+			name: "default project-path to current directory",
 			args: []string{"generate"},
 			setupMock: func(m *MockGenerateRunner) {
-				// Mock shouldn't be called
 				m.RunFunc = func(cmd *cobra.Command, projectPath, entrypoint string) error {
-					t.Error("RunFunc should not be called")
+					// Check that projectPath is set to current directory
+					cwd, _ := os.Getwd()
+					if projectPath != cwd {
+						t.Errorf("projectPath = %q, want %q (current directory)", projectPath, cwd)
+					}
+					fmt.Fprint(cmd.OutOrStdout(), "# Cliguard contract file\nuse: testapp\n")
 					return nil
 				}
 			},
-			wantErr: true,
+			wantErr: false,
 			checkFunc: func(t *testing.T, output string) {
-				if !contains(output, "required flag(s) \"project-path\" not set") {
-					t.Errorf("output = %q, want to contain %q", output, "required flag(s) \"project-path\" not set")
+				if !contains(output, "# Cliguard contract file") {
+					t.Errorf("output = %q, want to contain %q", output, "# Cliguard contract file")
 				}
 			},
 		},

--- a/test-suite/README.md
+++ b/test-suite/README.md
@@ -67,6 +67,7 @@ Or run individual tests:
 ```bash
 cd basic/simple-cli
 go build
-cliguard generate --project-path . --entrypoint "github.com/cliguard/test/simple.NewRootCmd" > contract.yaml
-cliguard validate --project-path . --entrypoint "github.com/cliguard/test/simple.NewRootCmd" --contract contract.yaml
+# project-path defaults to current directory
+cliguard generate --entrypoint "github.com/cliguard/test/simple.NewRootCmd" > contract.yaml
+cliguard validate --entrypoint "github.com/cliguard/test/simple.NewRootCmd" --contract contract.yaml
 ```


### PR DESCRIPTION
## Summary
This PR implements issue #9, making the `--project-path` flag optional for both `validate` and `generate` commands. When not specified, the commands now default to using the current working directory.

## Changes
- Modified `cmd/root.go` to handle empty project-path values by defaulting to `os.Getwd()`
- Updated flag descriptions to indicate the default behavior
- Updated `cliguard.yaml` usage descriptions to reflect that project-path is now optional

## Implementation Details
- Both `runValidate()` and `runGenerate()` functions now check if `projectPath` is empty
- When empty, they use `os.Getwd()` to get the current working directory
- Error handling is included for cases where `os.Getwd()` might fail
- Existing behavior with explicit project-path remains unchanged

## Test Plan
- [x] Verified that commands work without `--project-path` flag
- [x] Verified that explicit `--project-path` still works as before
- [x] Documentation updated to reflect the change

Closes #9