### PR TITLE
feat: Improve error messages for better debugging

### DIFF
--- a/cmd/root_extended_test.go
+++ b/cmd/root_extended_test.go
@@ -234,8 +234,8 @@ func TestDefaultValidateRunner(t *testing.T) {
 		if err == nil {
 			t.Error("Expected error for nonexistent project")
 		}
-		if !contains(err.Error(), "project path does not exist") {
-			t.Errorf("Error = %q, want to contain 'project path does not exist'", err.Error())
+		if !contains(err.Error(), "Project path does not exist") {
+			t.Errorf("Error = %q, want to contain 'Project path does not exist'", err.Error())
 		}
 	})
 
@@ -271,8 +271,8 @@ func TestValidateServiceIntegration(t *testing.T) {
 		if err == nil {
 			t.Error("Expected error for nonexistent project")
 		}
-		if !contains(err.Error(), "project path does not exist") {
-			t.Errorf("Error = %q, want to contain 'project path does not exist'", err.Error())
+		if !contains(err.Error(), "Project path does not exist") {
+			t.Errorf("Error = %q, want to contain 'Project path does not exist'", err.Error())
 		}
 	})
 
@@ -298,8 +298,8 @@ short: Test CLI
 			t.Error("Expected error for invalid project")
 		}
 		// The error will be from the inspector trying to run go commands
-		if !contains(err.Error(), "failed to inspect project") {
-			t.Errorf("Error = %q, want to contain 'failed to inspect project'", err.Error())
+		if !contains(err.Error(), "Failed to inspect project") {
+			t.Errorf("Error = %q, want to contain 'Failed to inspect project'", err.Error())
 		}
 	})
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -66,7 +66,7 @@ func TestRunValidate_Errors(t *testing.T) {
 			},
 			args:        []string{"--project-path", "/nonexistent/path"},
 			wantErr:     true,
-			errContains: "project path does not exist",
+			errContains: "Project path does not exist",
 		},
 		{
 			name: "contract_file_not_found",

--- a/internal/contract/parser_test.go
+++ b/internal/contract/parser_test.go
@@ -110,7 +110,7 @@ flags:
     type: badtype
 `,
 			wantErr:     true,
-			errContains: "flag 'config': invalid type 'badtype'",
+			errContains: "Invalid flag type 'badtype' for flag 'config'",
 		},
 		{
 			name: "invalid_duplicate_flag_names",
@@ -390,7 +390,7 @@ func TestLoadErrors(t *testing.T) {
 				return "/nonexistent/file.yaml"
 			},
 			wantErr:     true,
-			errContains: "failed to read contract file",
+			errContains: "Cannot load contract file",
 		},
 		{
 			name: "invalid_yaml",
@@ -401,7 +401,7 @@ func TestLoadErrors(t *testing.T) {
 				return tmpFile
 			},
 			wantErr:     true,
-			errContains: "failed to parse contract YAML",
+			errContains: "Failed to parse contract YAML file",
 		},
 	}
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,0 +1,240 @@
+package errors
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ContractNotFoundError indicates the contract file could not be found
+type ContractNotFoundError struct {
+	Path         string
+	SearchedPath string
+}
+
+func (e ContractNotFoundError) Error() string {
+	return fmt.Sprintf(`Cannot load contract file '%s': file not found
+
+Ensure the contract file exists or specify a different path with --contract flag.
+Example: cliguard validate --project-path . --contract ./mycontract.yaml
+
+To generate a new contract file:
+  cliguard generate --project-path . > cliguard.yaml`, e.Path)
+}
+
+// ContractParseError indicates the contract file could not be parsed
+type ContractParseError struct {
+	Path    string
+	Err     error
+	Content string
+}
+
+func (e ContractParseError) Error() string {
+	// Try to extract line number from YAML error
+	lineInfo := ""
+	if e.Err != nil {
+		errStr := e.Err.Error()
+		if strings.Contains(errStr, "line") {
+			lineInfo = "\n\n" + errStr
+		}
+	}
+
+	return fmt.Sprintf(`Failed to parse contract YAML file '%s'%s
+
+Common issues:
+  - Incorrect indentation (YAML requires consistent spaces, not tabs)
+  - Missing quotes around special characters
+  - Invalid flag types (check supported types in documentation)
+
+To validate your YAML syntax:
+  cat %s | yq eval . -`, e.Path, lineInfo, e.Path)
+}
+
+// InvalidContractError indicates the contract has validation errors
+type InvalidContractError struct {
+	Path    string
+	Message string
+}
+
+func (e InvalidContractError) Error() string {
+	return fmt.Sprintf(`Contract validation failed in '%s':
+%s
+
+Please fix the contract file and try again.`, e.Path, e.Message)
+}
+
+// ProjectNotFoundError indicates the project path does not exist
+type ProjectNotFoundError struct {
+	Path string
+}
+
+func (e ProjectNotFoundError) Error() string {
+	return fmt.Sprintf(`Project path does not exist: '%s'
+
+Please ensure the path is correct or use --project-path to specify a different location.
+Current directory: %s`, e.Path, getCurrentDir())
+}
+
+// EntrypointParseError indicates the entrypoint format is invalid
+type EntrypointParseError struct {
+	Entrypoint string
+	Reason     string
+}
+
+func (e EntrypointParseError) Error() string {
+	return fmt.Sprintf(`Failed to parse entrypoint '%s': %s
+
+Expected format: package.Function or github.com/user/repo/package.Function
+Examples:
+  - main.NewRootCmd
+  - github.com/spf13/cobra/cmd.Execute
+  - internal/cmd.NewRootCommand`, e.Entrypoint, e.Reason)
+}
+
+// InspectionError indicates the project inspection failed
+type InspectionError struct {
+	ProjectPath string
+	Entrypoint  string
+	Err         error
+}
+
+func (e InspectionError) Error() string {
+	msg := fmt.Sprintf(`Failed to inspect project at '%s'`, e.ProjectPath)
+
+	if e.Entrypoint != "" {
+		msg += fmt.Sprintf(` with entrypoint '%s'`, e.Entrypoint)
+	}
+
+	msg += fmt.Sprintf(`: %v
+
+Common causes:
+  - Project is not a valid Go module (missing go.mod)
+  - Entrypoint function does not exist or is not exported
+  - Build errors in the project
+  - Missing dependencies
+
+To debug:
+  1. Ensure 'go build' works in your project directory
+  2. Verify the entrypoint function exists and returns *cobra.Command
+  3. Try running 'go mod tidy' to resolve dependencies`, e.Err)
+
+	return msg
+}
+
+// TempDirError indicates temporary directory operations failed
+type TempDirError struct {
+	Operation string
+	Err       error
+}
+
+func (e TempDirError) Error() string {
+	return fmt.Sprintf(`Failed to %s temporary directory: %v
+
+This might be due to:
+  - Insufficient disk space
+  - Permission issues in temp directory
+  - System temp directory not accessible
+
+Try setting TMPDIR environment variable to a writable directory:
+  export TMPDIR=/path/to/writable/directory`, e.Operation, e.Err)
+}
+
+// DependencyError indicates Go module dependency resolution failed
+type DependencyError struct {
+	Operation string
+	Output    string
+	Err       error
+}
+
+func (e DependencyError) Error() string {
+	return fmt.Sprintf(`Failed to resolve Go module dependencies: %v
+
+Operation: %s
+
+This might be due to:
+  - Network connectivity issues
+  - Private repository access problems
+  - Incompatible dependency versions
+
+To debug:
+  1. Run 'go mod download' in your project
+  2. Check GOPROXY and GOPRIVATE settings
+  3. Ensure all dependencies are accessible
+
+Output:
+%s`, e.Err, e.Operation, e.Output)
+}
+
+// FlagTypeError indicates an unsupported flag type
+type FlagTypeError struct {
+	FlagName    string
+	InvalidType string
+	ValidTypes  []string
+}
+
+func (e FlagTypeError) Error() string {
+	return fmt.Sprintf(`Invalid flag type '%s' for flag '%s'
+
+Supported types:
+%s
+
+Example flag definition:
+  flags:
+    - name: %s
+      type: string  # Change to one of the supported types
+      description: "Your flag description"`,
+		e.InvalidType,
+		e.FlagName,
+		formatValidTypes(e.ValidTypes),
+		e.FlagName)
+}
+
+// Helper functions
+
+func getCurrentDir() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "<unable to determine>"
+	}
+	return dir
+}
+
+func formatValidTypes(types []string) string {
+	var result []string
+	for _, t := range types {
+		result = append(result, fmt.Sprintf("  - %s", t))
+	}
+	return strings.Join(result, "\n")
+}
+
+// IsContractNotFound checks if an error is a ContractNotFoundError
+func IsContractNotFound(err error) bool {
+	_, ok := err.(ContractNotFoundError)
+	return ok
+}
+
+// IsProjectNotFound checks if an error is a ProjectNotFoundError
+func IsProjectNotFound(err error) bool {
+	_, ok := err.(ProjectNotFoundError)
+	return ok
+}
+
+// IsEntrypointParseError checks if an error is an EntrypointParseError
+func IsEntrypointParseError(err error) bool {
+	_, ok := err.(EntrypointParseError)
+	return ok
+}
+
+// WrapContractNotFound wraps a file not found error as ContractNotFoundError
+func WrapContractNotFound(path string, err error) error {
+	if os.IsNotExist(err) {
+		absPath, _ := filepath.Abs(path)
+		return ContractNotFoundError{
+			Path:         path,
+			SearchedPath: absPath,
+		}
+	}
+	return err
+}
+

--- a/internal/inspector/inspector_refactored_test.go
+++ b/internal/inspector/inspector_refactored_test.go
@@ -224,7 +224,7 @@ func TestInspector_Inspect(t *testing.T) {
 				fs.MkdirTempErr = errors.New("permission denied")
 			},
 			wantErr:       true,
-			wantErrString: "failed to create temp directory",
+			wantErrString: "Failed to create temporary directory",
 		},
 		{
 			name: "invalid entrypoint",
@@ -234,7 +234,7 @@ func TestInspector_Inspect(t *testing.T) {
 			},
 			setupMocks:    func(fs *filesystem.MockFileSystem, exec *executor.MockExecutor) {},
 			wantErr:       true,
-			wantErrString: "failed to parse entrypoint",
+			wantErrString: "Failed to parse entrypoint",
 		},
 		{
 			name: "go mod init failure",

--- a/internal/validator/types.go
+++ b/internal/validator/types.go
@@ -10,11 +10,12 @@ type ValidationResult struct {
 
 // ValidationError represents a single validation failure
 type ValidationError struct {
-	Type     ErrorType
-	Path     string
-	Expected string
-	Actual   string
-	Message  string
+	Type        ErrorType
+	Path        string
+	Expected    string
+	Actual      string
+	Message     string
+	Description string // Additional descriptive text for the error
 }
 
 // ErrorType defines the type of validation error
@@ -35,37 +36,94 @@ func (vr *ValidationResult) IsValid() bool {
 // AddError adds a new validation error to the result
 func (vr *ValidationResult) AddError(errorType ErrorType, path, expected, actual, message string) {
 	vr.Errors = append(vr.Errors, ValidationError{
-		Type:     errorType,
-		Path:     path,
-		Expected: expected,
-		Actual:   actual,
-		Message:  message,
+		Type:        errorType,
+		Path:        path,
+		Expected:    expected,
+		Actual:      actual,
+		Message:     message,
+		Description: message, // For backward compatibility, use message as description
+	})
+	vr.Valid = false
+}
+
+// AddErrorWithDescription adds a new validation error with a separate description
+func (vr *ValidationResult) AddErrorWithDescription(errorType ErrorType, path, expected, actual, message, description string) {
+	vr.Errors = append(vr.Errors, ValidationError{
+		Type:        errorType,
+		Path:        path,
+		Expected:    expected,
+		Actual:      actual,
+		Message:     message,
+		Description: description,
 	})
 	vr.Valid = false
 }
 
 // PrintReport prints a human-readable validation report
 func (vr *ValidationResult) PrintReport() {
+	// Group errors by type for better organization
+	var missingErrors, unexpectedErrors, mismatchErrors, invalidTypeErrors []ValidationError
+
 	for _, err := range vr.Errors {
 		switch err.Type {
 		case ErrorTypeMissing:
-			fmt.Printf("- %s: Missing %s\n", err.Path, err.Message)
-			if err.Expected != "" {
-				fmt.Printf("    Expected: %s\n", err.Expected)
-			}
+			missingErrors = append(missingErrors, err)
 		case ErrorTypeUnexpected:
-			fmt.Printf("- %s: Unexpected %s\n", err.Path, err.Message)
-			if err.Actual != "" {
-				fmt.Printf("    Found: %s\n", err.Actual)
-			}
+			unexpectedErrors = append(unexpectedErrors, err)
 		case ErrorTypeMismatch:
-			fmt.Printf("- %s: %s\n", err.Path, err.Message)
-			fmt.Printf("    Expected: %s\n", err.Expected)
-			fmt.Printf("    Actual:   %s\n", err.Actual)
+			mismatchErrors = append(mismatchErrors, err)
 		case ErrorTypeInvalidType:
-			fmt.Printf("- %s: %s\n", err.Path, err.Message)
-			fmt.Printf("    Expected type: %s\n", err.Expected)
-			fmt.Printf("    Actual type:   %s\n", err.Actual)
+			invalidTypeErrors = append(invalidTypeErrors, err)
 		}
 	}
+
+	// Print missing errors
+	if len(missingErrors) > 0 {
+		fmt.Println("\n❌ Missing items:")
+		for _, err := range missingErrors {
+			fmt.Printf("   • %s: %s\n", err.Description, err.Path)
+			if err.Expected != "" {
+				fmt.Printf("     Add to contract: %s\n", err.Expected)
+			}
+		}
+	}
+
+	// Print unexpected errors
+	if len(unexpectedErrors) > 0 {
+		fmt.Println("\n❌ Unexpected items:")
+		for _, err := range unexpectedErrors {
+			fmt.Printf("   • %s\n", err.Path)
+			fmt.Printf("     %s\n", err.Message)
+			if err.Actual != "" {
+				fmt.Printf("     Found: %s\n", err.Actual)
+			}
+		}
+	}
+
+	// Print mismatch errors
+	if len(mismatchErrors) > 0 {
+		fmt.Println("\n❌ Mismatches:")
+		for _, err := range mismatchErrors {
+			fmt.Printf("   • %s\n", err.Path)
+			fmt.Printf("     Contract: %s\n", err.Expected)
+			fmt.Printf("     Actual:   %s\n", err.Actual)
+			if err.Description != "" {
+				fmt.Printf("     %s\n", err.Description)
+			}
+		}
+	}
+
+	// Print invalid type errors
+	if len(invalidTypeErrors) > 0 {
+		fmt.Println("\n❌ Invalid types:")
+		for _, err := range invalidTypeErrors {
+			fmt.Printf("   • %s\n", err.Path)
+			fmt.Printf("     %s\n", err.Message)
+			fmt.Printf("     Expected type: %s\n", err.Expected)
+			fmt.Printf("     Actual type:   %s\n", err.Actual)
+		}
+	}
+
+	// Print summary
+	fmt.Printf("\nTotal errors: %d\n", len(vr.Errors))
 }


### PR DESCRIPTION
## Summary

Implements comprehensive error message improvements as described in issue #4, replacing generic error messages with detailed, actionable guidance that helps users understand and fix problems.

## Changes Made

### New Error Package
- Created `internal/errors/errors.go` with 9 structured error types
- Each error type provides context, common causes, and actionable solutions
- Added helper functions for error type checking and wrapping

### Error Types Implemented
- **ContractNotFoundError**: Clear guidance on creating/specifying contracts
- **ContractParseError**: YAML debugging tips and syntax validation help  
- **InvalidContractError**: Contract validation failure details
- **ProjectNotFoundError**: Path verification with current directory info
- **EntrypointParseError**: Format examples and expected patterns
- **InspectionError**: Common causes and debugging steps
- **TempDirError**: System issues and workarounds
- **DependencyError**: Go module resolution help
- **FlagTypeError**: Lists all supported types with examples

### Updated Components
- `internal/contract/parser.go`: Uses new structured error types
- `internal/inspector/inspector_refactored.go`: Better error context and guidance
- `internal/service/validate.go`: Enhanced project and inspection error handling
- `internal/validator/types.go`: Completely redesigned PrintReport with grouped, formatted output

### Enhanced Validation Output
- Errors grouped by type (❌ Missing items, ❌ Unexpected items, etc.)
- Clear visual formatting with emoji indicators
- Actionable suggestions for each error category
- Summary with total error count

## Before vs After

### Before
```
Error: failed to load contract: failed to read contract file: open /path/contract.yaml: no such file or directory
```

### After
```
Cannot load contract file '/path/contract.yaml': file not found

Ensure the contract file exists or specify a different path with --contract flag.
Example: cliguard validate --project-path . --contract ./mycontract.yaml

To generate a new contract file:
  cliguard generate --project-path . > cliguard.yaml
```

## Test Plan

✅ All existing tests pass with updated expectations  
✅ Error messages tested across all failure scenarios  
✅ Code formatting and basic linting applied  
✅ Manual testing confirms improved user experience  

## Closes

Closes #4

🤖 Generated with [Claude Code](https://claude.ai/code)