### PR TITLE
Fix: Generate complete entrypoints for all Cobra patterns in discover command

### DIFF
--- a/internal/discovery/interactive.go
+++ b/internal/discovery/interactive.go
@@ -86,8 +86,15 @@ func (s *InteractiveSelector) SelectCandidate(candidates []EntrypointCandidate) 
 
 // FormatSelectedEntrypoint formats the selected entrypoint for display
 func FormatSelectedEntrypoint(candidate *EntrypointCandidate) string {
-	if candidate.FunctionSignature != "" && strings.Contains(candidate.FunctionSignature, "NewRootCmd") {
-		return fmt.Sprintf("--entrypoint %s.NewRootCmd", candidate.PackagePath)
+	entrypoint := candidate.PackagePath
+	
+	// For Cobra CLIs, try to determine the correct function name
+	if candidate.Framework == "cobra" {
+		functionName := determineCObraFunctionName(*candidate)
+		if functionName != "" {
+			entrypoint = candidate.PackagePath + "." + functionName
+		}
 	}
-	return fmt.Sprintf("--entrypoint %s", candidate.PackagePath)
+	
+	return fmt.Sprintf("--entrypoint %s", entrypoint)
 }

--- a/internal/discovery/interactive_test.go
+++ b/internal/discovery/interactive_test.go
@@ -145,25 +145,53 @@ func TestFormatSelectedEntrypoint(t *testing.T) {
 		{
 			name: "NewRootCmd function",
 			candidate: EntrypointCandidate{
+				Framework:         "cobra",
 				FunctionSignature: "func NewRootCmd() *cobra.Command",
 				PackagePath:       "github.com/test/project/cmd",
+				Pattern:           "Function returning root cobra.Command",
+				Line:              "func NewRootCmd() *cobra.Command {",
 			},
 			expected: "--entrypoint github.com/test/project/cmd.NewRootCmd",
 		},
 		{
-			name: "no function signature",
+			name: "no function signature - non-cobra",
 			candidate: EntrypointCandidate{
+				Framework:   "flag",
 				PackagePath: "github.com/test/project",
 			},
 			expected: "--entrypoint github.com/test/project",
 		},
 		{
-			name: "different function name",
+			name: "Execute function - cobra",
 			candidate: EntrypointCandidate{
+				Framework:         "cobra",
 				FunctionSignature: "func Execute()",
 				PackagePath:       "github.com/test/project/cmd",
+				Pattern:           "Cobra Execute function",
+				Line:              "func Execute() {",
 			},
-			expected: "--entrypoint github.com/test/project/cmd",
+			expected: "--entrypoint github.com/test/project/cmd.NewRootCmd",
+		},
+		{
+			name: "Root command initialization - cobra",
+			candidate: EntrypointCandidate{
+				Framework:   "cobra",
+				PackagePath: "github.com/test/project/cmd",
+				Pattern:     "Root command initialization",
+				Line:        "rootCmd := &cobra.Command{",
+			},
+			expected: "--entrypoint github.com/test/project/cmd.NewRootCmd",
+		},
+		{
+			name: "NewRootCmd().Execute() call - cobra",
+			candidate: EntrypointCandidate{
+				Framework:         "cobra",
+				FunctionSignature: "func ExecuteWithWriter(errWriter io.Writer)",
+				PackagePath:       "github.com/test/project/cmd",
+				Pattern:           "Cobra Execute function",
+				Line:              "if err := NewRootCmd().Execute(); err != nil {",
+			},
+			expected: "--entrypoint github.com/test/project/cmd.NewRootCmd",
 		},
 	}
 


### PR DESCRIPTION
## Summary

- Fixes the discover command generating incomplete entrypoints for certain Cobra patterns
- Enhances both command-line and interactive discover functionality to provide complete, usable entrypoints
- Adds comprehensive test coverage for all Cobra pattern types

## Problem

The `cliguard discover` command was suggesting incomplete entrypoints that only specified package paths without function names, making them unusable:

**Before (Broken):**
```bash
cliguard generate --entrypoint "github.com/hiAndrewQuinn/cliguard/cmd"
# Error: failed to inspect project
```

**After (Fixed):**
```bash
cliguard generate --entrypoint "github.com/hiAndrewQuinn/cliguard/cmd.NewRootCmd"
# Works correctly
```

## Root Cause

The `formatGenerateCommand()` function only appended `.NewRootCmd` when function signatures explicitly contained "NewRootCmd", but ignored other valid Cobra patterns like:
- "Cobra Execute function" (detecting `Execute()` calls)  
- "Root command initialization" (detecting `rootCmd := &cobra.Command{}`)

## Solution

Enhanced entrypoint detection with intelligent function name resolution:

1. **Pattern-based detection:** Analyzes specific Cobra patterns to determine correct function names
2. **Function signature parsing:** Extracts function names from signatures returning `*cobra.Command`
3. **Heuristic fallbacks:** Uses `NewRootCmd` as standard entry point for ambiguous patterns
4. **Unified logic:** Both command-line discover and interactive selection use same detection

### Key Improvements

- **"Cobra Execute function" patterns** → resolve to `.NewRootCmd` (standard entry point)
- **"Root command initialization" patterns** → resolve to `.NewRootCmd` (heuristic)  
- **NewRootCmd().Execute() calls** → resolve to `.NewRootCmd` (extracted from line content)
- **Functions returning *cobra.Command** → extract actual function name from signature

## Test Plan

- [x] All existing tests pass with no regressions
- [x] Added comprehensive test cases covering all Cobra patterns
- [x] Manual testing confirms previously failing commands now work
- [x] Interactive discover functionality also fixed
- [x] Verified fix works after rebase to latest main

## Files Changed

- `internal/discovery/discovery.go`: Enhanced `formatGenerateCommand()` with new `determineCObraFunctionName()` helper
- `internal/discovery/interactive.go`: Updated `FormatSelectedEntrypoint()` to use same logic  
- `internal/discovery/interactive_test.go`: Added comprehensive test coverage for all pattern types

## Testing Commands

**Verify the fix works:**
```bash
./cliguard discover --project-path . | grep "Command:"
# All commands should now have complete entrypoints with function names
```

**Test specific patterns that were failing:**
```bash
./cliguard generate --project-path . --entrypoint "github.com/hiAndrewQuinn/cliguard/cmd.NewRootCmd"
# Should generate complete contract (was previously failing with incomplete entrypoint)
```

Resolves #25

🤖 Generated with [Claude Code](https://claude.ai/code)