### PR TITLE
Fix: Resolve test failures and PrintReport formatting issues

### DIFF
--- a/cmd/root_extended_test.go
+++ b/cmd/root_extended_test.go
@@ -214,6 +214,16 @@ func TestDefaultValidateRunner(t *testing.T) {
 			return nil, errors.New("project not found")
 		}
 
+		runner.service.InspectorWithTimeout = func(projectPath, entrypoint string, timeout time.Duration) (*inspector.InspectedCLI, error) {
+			if projectPath == tmpDir {
+				return &inspector.InspectedCLI{
+					Use:   "myapp",
+					Short: "My app",
+				}, nil
+			}
+			return nil, errors.New("project not found")
+		}
+
 		cmd := &cobra.Command{}
 		buf := new(bytes.Buffer)
 		cmd.SetOut(buf)

--- a/internal/validator/types.go
+++ b/internal/validator/types.go
@@ -81,7 +81,11 @@ func (vr *ValidationResult) PrintReport() {
 	if len(missingErrors) > 0 {
 		fmt.Println("\n❌ Missing items:")
 		for _, err := range missingErrors {
-			fmt.Printf("   • %s: %s\n", err.Description, err.Path)
+			if err.Description != "" {
+				fmt.Printf("   • %s: %s\n", err.Description, err.Path)
+			} else {
+				fmt.Printf("   • %s\n", err.Path)
+			}
 			if err.Expected != "" {
 				fmt.Printf("     Add to contract: %s\n", err.Expected)
 			}


### PR DESCRIPTION
## Summary

This PR fixes both issues identified in #28:

• **Fixed TestDefaultValidateRunner/success test failure** - Added missing `InspectorWithTimeout` mock
• **Fixed PrintReport formatting for empty Description fields** - Clean output format without confusing colons

## Changes Made

### 1. Test Fix (`cmd/root_extended_test.go`)
- Added `InspectorWithTimeout` mock in `TestDefaultValidateRunner/success` 
- The test was calling `ValidateService.Validate` with a timeout, which uses `InspectorWithTimeout` instead of the regular `Inspector` function
- Now properly mocks both `Inspector` and `InspectorWithTimeout` functions

### 2. PrintReport Formatting (`internal/validator/types.go`)  
- Updated `PrintReport()` method to handle empty `Description` fields gracefully
- **Before:** `• : test --flag` (confusing empty description prefix)
- **After:** `• test --flag` (clean, readable output)
- Maintains backward compatibility for non-empty descriptions

## Test Results

✅ All tests now pass with `make test`
✅ No regressions introduced 
✅ Clean validation output formatting

## Test Plan

1. ✅ Run `make test` - all tests pass
2. ✅ Verify `TestDefaultValidateRunner/success` specifically passes
3. ✅ Check PrintReport output shows clean formatting without empty description prefixes

Closes #28

🤖 Generated with [Claude Code](https://claude.ai/code)